### PR TITLE
Display links only if available

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
   publish = "public/"
   command = "npm run build"
 
-[context.xue-card]
+[context.2020-fall]
   publish = "public/"
   command = "npm run build"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
-  publish = "build/"
-  command = "yarn build"
+  publish = "public/"
+  command = "npm run build"
 
 [context.branch-deploy]
   publish = "public/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,12 @@
 [build]
-  publish = "public/"
-  command = "npm run build"
+  publish = "build/"
+  command = "yarn build"
 
 [context.branch-deploy]
   publish = "public/"
   command = "npm run build"
 
-[context.2020-fall]
+[context.xue-card]
   publish = "public/"
   command = "npm run build"
 

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -40,8 +40,8 @@ const Card = (props: {level: string; time: string; dependency: string; dependenc
       {props.dependencyLink ?  ". Setup at: ": ""}<a target="_blank" className="link" href={props.dependencyLink }>{props.dependencyLink ?  props.dependencyLink: ""}</a></i> 
     </p>
     <p>
-      {props.codeLink === 'N/A' ? null : <b>Code: </b><a target="_blank" className="link" href={props.codeLink}>GitHub</a><br/>}
-      {props.slidesLink === 'N/A' ? null : <b>Slides: </b><a target="_blank" className="link" href={props.slidesLink}>Google Slides</a><br/>}
+      {props.codeLink === 'N/A' ? null : '<b>Code: </b><a target="_blank" className="link" href={props.codeLink}>GitHub</a><br/>'}
+      {props.slidesLink === 'N/A' ? null : '<b>Slides: </b><a target="_blank" className="link" href={props.slidesLink}>Google Slides</a><br/>'}
     </p>
     </>
   )

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -40,8 +40,8 @@ const Card = (props: {level: string; time: string; dependency: string; dependenc
       {props.dependencyLink ?  ". Setup at: ": ""}<a target="_blank" className="link" href={props.dependencyLink }>{props.dependencyLink ?  props.dependencyLink: ""}</a></i> 
     </p>
     <p>
-      {props.codeLink === 'N/A' ? null : '<b>Code: </b><a target="_blank" className="link" href={props.codeLink}>GitHub</a><br/>'}
-      {props.slidesLink === 'N/A' ? null : '<b>Slides: </b><a target="_blank" className="link" href={props.slidesLink}>Google Slides</a><br/>'}
+      {props.codeLink === 'N/A' ? null : <><b>Code: </b><a target="_blank" className="link" href={props.codeLink}>GitHub</a><br/></>}
+      {props.slidesLink === 'N/A' ? null : <><b>Slides: </b><a target="_blank" className="link" href={props.slidesLink}>Google Slides</a><br/></>}
     </p>
     </>
   )

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -40,8 +40,8 @@ const Card = (props: {level: string; time: string; dependency: string; dependenc
       {props.dependencyLink ?  ". Setup at: ": ""}<a target="_blank" className="link" href={props.dependencyLink }>{props.dependencyLink ?  props.dependencyLink: ""}</a></i> 
     </p>
     <p>
-      <b>Code</b>: <a target="_blank" className="link" href={props.codeLink}>{props.codeLink == 'N/A' ? 'N/A': 'Code on Github'}</a><br/> 
-      <b>Slides</b>: <a target="_blank" className="link"  href={props.slidesLink}>{props.slidesLink == 'N/A' ? 'N/A': 'Google Slides'}</a><br/> 
+      {props.codeLink === 'N/A' ? null : <b>Code: <b><a target="_blank" className="link" href={props.codeLink}>GitHub</a><br/>}
+      {props.slidesLink === 'N/A' ? null : <b>Slides: <b><a target="_blank" className="link" href={props.slidesLink}>Google Slides</a><br/>}
     </p>
     </>
   )

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -40,8 +40,8 @@ const Card = (props: {level: string; time: string; dependency: string; dependenc
       {props.dependencyLink ?  ". Setup at: ": ""}<a target="_blank" className="link" href={props.dependencyLink }>{props.dependencyLink ?  props.dependencyLink: ""}</a></i> 
     </p>
     <p>
-      {props.codeLink === 'N/A' ? null : <b>Code: <b><a target="_blank" className="link" href={props.codeLink}>GitHub</a><br/>}
-      {props.slidesLink === 'N/A' ? null : <b>Slides: <b><a target="_blank" className="link" href={props.slidesLink}>Google Slides</a><br/>}
+      {props.codeLink === 'N/A' ? null : <b>Code: </b><a target="_blank" className="link" href={props.codeLink}>GitHub</a><br/>}
+      {props.slidesLink === 'N/A' ? null : <b>Slides: </b><a target="_blank" className="link" href={props.slidesLink}>Google Slides</a><br/>}
     </p>
     </>
   )


### PR DESCRIPTION
Useful since currently, even the N/A gets formatted as a link on learn.vh which leads to https://learn.vandyhacks.org/N/A that doesn't exist.

Also eliminates redundancy by linking to GitHub after Code like how it's done with Slides right now.