### PR TITLE
increase card link visibility and readability

### DIFF
--- a/src/components/card.css
+++ b/src/components/card.css
@@ -23,8 +23,8 @@
 .card a {
   text-decoration: none;
   font-family: Roboto, sans-serif;
-
-  color: rgba(0, 0, 0, 0.6);
+  font-weight: bold;
+  color: rgb(63, 51, 238);
 }
 
 .inactive a:hover{


### PR DESCRIPTION
increase card link visibility and readability by changing the link color from grey to a bolded blue. this helps distinguish the linked text from the non-linked text, making it more easily identifiable as a link and helps people find the links at a glance.